### PR TITLE
fix: text input field not typing space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aria-ease",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "description": "Out-of-the-box accessibility utility package to develop production ready applications.",
   "main": "index.js",
   "scripts": {

--- a/src/handleKeyPress.js
+++ b/src/handleKeyPress.js
@@ -40,12 +40,13 @@ export function handleKeyPress(event, elementItems, elementItemIndex, menuElemen
             break;
         case 'Enter':
         case ' ':
-            event.preventDefault();
             if (elementItems.item(elementItemIndex).tagName === 'BUTTON') {
+                event.preventDefault();
                 elementItems.item(elementItemIndex).click();
                 break;
             }
             else if (elementItems.item(elementItemIndex).tagName === 'A') {
+                event.preventDefault();
                 window.location.href = elementItems.item(elementItemIndex).href;
                 break;
             }

--- a/src/handleKeyPress.ts
+++ b/src/handleKeyPress.ts
@@ -42,11 +42,12 @@ export function handleKeyPress(event: KeyboardEvent, elementItems: NodeListOfHTM
             break;
         case 'Enter':
         case ' ':
-            event.preventDefault()
             if(elementItems.item(elementItemIndex).tagName === 'BUTTON') {
+                event.preventDefault()
                 elementItems.item(elementItemIndex).click();
                 break;
             } else if (elementItems.item(elementItemIndex).tagName === 'A') {
+                event.preventDefault()
                 window.location.href = elementItems.item(elementItemIndex).href; 
                 break;
             }


### PR DESCRIPTION
Keyboard navigable text input fields was not allow space to be typed because the Space key press case in the handleKeyPress method was preventing the default event handling.